### PR TITLE
Switch Phab dependencies to GH

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ end
 
 gem 'bcrypt', '~> 3.1.7'
 gem 'money-rails'
-gem 'omisego', '0.9.0', git: 'ssh://git@github.com/omisego/sdk-ruby.git', tag: 'v0.9.0'
+gem 'omisego', '0.9.0', git: 'ssh://git@github.com/omisego/ruby-sdk.git', tag: 'v0.9.0'
 gem 'pg'
 gem 'puma', '~> 3.7'
 gem 'rails', '~> 5.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: ssh://git@github.com/omisego/sdk-ruby.git
+  remote: ssh://git@github.com/omisego/ruby-sdk.git
   revision: 146ff34bf59840116aac3037b8a110777d7b55a8
   tag: v0.9.0
   specs:


### PR DESCRIPTION
This PR switches the dependencies URLs from Phabricator to GitHub.