### PR TITLE
Add Rails logger for SDK requests

### DIFF
--- a/config/initializers/omisego.rb
+++ b/config/initializers/omisego.rb
@@ -2,4 +2,5 @@ OmiseGO.configure do |config|
   config.access_key = ENV['OMISEGO_ACCESS_KEY']
   config.secret_key = ENV['OMISEGO_SECRET_KEY']
   config.base_url   = ENV['OMISEGO_WALLET_URL']
+  config.logger     = Rails.logger
 end


### PR DESCRIPTION
In order to debug problems more easily, this PR adds the `Rails.logger` to log all SDK calls to the eWallet.