### PR TITLE
Add eWallet account ID to Helm chart.

### DIFF
--- a/contrib/charts/omgshop/templates/deployment.yaml
+++ b/contrib/charts/omgshop/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
               value: {{ .Values.ewalletAccessKey | quote }}
             - name: OMISEGO_SECRET_KEY
               value: {{ .Values.ewalletSecretKey | quote }}
+            - name: ACCOUNT_ID
+              value: {{ .Values.ewalletAccountId | quote }}
           {{- if .Values.omgshopDbUrl | default "" | ne "" }}
             - name: DATABASE_URL
               value: {{ .Values.omgshopDbUrl | quote }}

--- a/contrib/charts/omgshop/values.yaml
+++ b/contrib/charts/omgshop/values.yaml
@@ -7,6 +7,7 @@ omgshopSentryDsn: ""
 ewalletUrl: ""
 ewalletAccessKey: ""
 ewalletSecretKey: ""
+ewalletAccountId: ""
 
 image:
   repository: gcr.io/omise-go/omgshop


### PR DESCRIPTION
# Overview

Add `ACCOUNT_ID` support to Sample Server helm chart to support the API scheme.

# Changes

Add `ewalletAccountId` to the Helm chart.

# Implementation Details

Add an `ewalletAccountId` configuration in Helm chart as well as the default in `values.yaml`. The configuration key maps to `ACCOUNT_ID` environment variable in the Sample Server app.

# Usage

N/A

# Impact

Configure `ewalletAccountId` as appropriate.